### PR TITLE
Replace two surrogates with unicode code point

### DIFF
--- a/msxtileforge.py
+++ b/msxtileforge.py
@@ -2634,7 +2634,7 @@ class ImageImportDialog(tk.Toplevel):
         
         auto_frame = ttk.Frame(legend_frame)
         auto_frame.pack(anchor="w")
-        ttk.Label(auto_frame, text="\uD83D\uDD8C", font=icon_font).pack(side="left")
+        ttk.Label(auto_frame, text="🖌️", font=icon_font).pack(side="left")
         ttk.Label(auto_frame, text="= Auto: Script chooses the best color.").pack(side="left", padx=5)
         
         fixed_frame = ttk.Frame(legend_frame)
@@ -2752,7 +2752,7 @@ class ImageImportDialog(tk.Toplevel):
         canvas.create_rectangle(0, 0, 33, 33, fill=bg_color, outline="grey70")
         
         icon = ""
-        if state == "auto": icon = "\uD83D\uDD8C" # Brush emoji
+        if state == "auto": icon = "🖌️" # Brush emoji
         elif state == "fixed": icon = "📌"
         elif state == "blocked": icon = "\u26D4" # Prohibited/No Entry sign
         


### PR DESCRIPTION
The two surrogates works in windows because it uses UTF-16 internally, but it causes exception in Linux which uses UTF-8 internally:
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib64/python3.13/tkinter/__init__.py", line 2074, in __call__
    return self.func(*args)
           ~~~~~~~~~^^^^^^^
  File "/home/pedro/Projects/python/damnangel2/msx-tile-forge/./msxtileforge.py", line 15453, in import_tiles_from_image
    dialog = ImageTileImportDialog(self.root, self, image_filepath)
  File "/home/pedro/Projects/python/damnangel2/msx-tile-forge/./msxtileforge.py", line 2828, in __init__
    super().__init__(parent, app_instance, image_path)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pedro/Projects/python/damnangel2/msx-tile-forge/./msxtileforge.py", line 2581, in __init__
    self._build_ui()
    ~~~~~~~~~~~~~~^^
  File "/home/pedro/Projects/python/damnangel2/msx-tile-forge/./msxtileforge.py", line 2832, in _build_ui
    super()._build_ui()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/pedro/Projects/python/damnangel2/msx-tile-forge/./msxtileforge.py", line 2637, in _build_ui
    ttk.Label(auto_frame, text="\uD83D\uDD8C", font=icon_font).pack(side="left")
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/tkinter/ttk.py", line 739, in __init__
    Widget.__init__(self, master, "ttk::label", kw)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/tkinter/ttk.py", line 534, in __init__
    tkinter.Widget.__init__(self, master, widgetname, kw=kw)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/tkinter/__init__.py", line 2780, in __init__
    self.tk.call(
    ~~~~~~~~~~~~^
        (widgetName, self._w) + extra + self._options(cnf))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 0-1: surrogates not allowed
```